### PR TITLE
fix Artemis location in windows build

### DIFF
--- a/StarWarrior/StarWarrior/StarWarrior.csproj
+++ b/StarWarrior/StarWarrior/StarWarrior.csproj
@@ -67,7 +67,7 @@
   <ItemGroup>
     <Reference Include="artemis, Version=2.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\artemis_CSharp\Artemis_XNA_INDEPENDENT\bin\Debug\PC\artemis.dll</HintPath>
+      <HintPath>ArtemisDLL\$(Configuration)\PC\artemis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" />
     <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">


### PR DESCRIPTION
It wouldn't build the Windows project until I fixed the relative path for the Artemis DLL.
