### PR TITLE
Process() is protected instead of public

### DIFF
--- a/StarWarrior/StarWarrior/Systems/EnemyShipMovementSystem.cs
+++ b/StarWarrior/StarWarrior/Systems/EnemyShipMovementSystem.cs
@@ -64,7 +64,7 @@ namespace StarWarrior.Systems
 
         /// <summary>Processes the specified entity.</summary>
         /// <param name="entity">The entity.</param>
-        public override void Process(Entity entity,TransformComponent transformComponent,VelocityComponent velocityComponent,EnemyComponent enemyComponent)
+        protected override void Process(Entity entity,TransformComponent transformComponent,VelocityComponent velocityComponent,EnemyComponent enemyComponent)
         {
             if (transformComponent != null && (transformComponent.X < 0 || transformComponent.X > this.spriteBatch.GraphicsDevice.Viewport.Width))
             {

--- a/StarWarrior/StarWarrior/Systems/EnemyShooterSystem.cs
+++ b/StarWarrior/StarWarrior/Systems/EnemyShooterSystem.cs
@@ -62,7 +62,7 @@ namespace StarWarrior.Systems
 
         /// <summary>Processes the specified entity.</summary>
         /// <param name="entity">The entity.</param>
-        public override void Process(Entity entity,TransformComponent transformComponent,WeaponComponent weaponComponent,EnemyComponent enemyComponent)
+        protected override void Process(Entity entity,TransformComponent transformComponent,WeaponComponent weaponComponent,EnemyComponent enemyComponent)
         {
             if (weaponComponent != null)
             {

--- a/StarWarrior/StarWarrior/Systems/ExpirationSystem.cs
+++ b/StarWarrior/StarWarrior/Systems/ExpirationSystem.cs
@@ -54,7 +54,7 @@ namespace StarWarrior.Systems
     {
         /// <summary>Processes the specified entity.</summary>
         /// <param name="entity">The entity.</param>
-        public override void Process(Entity entity,ExpiresComponent expiresComponent)
+        protected override void Process(Entity entity,ExpiresComponent expiresComponent)
         {
             if (expiresComponent != null)
             {

--- a/StarWarrior/StarWarrior/Systems/HealthBarRenderSystem.cs
+++ b/StarWarrior/StarWarrior/Systems/HealthBarRenderSystem.cs
@@ -69,7 +69,7 @@ namespace StarWarrior.Systems
 
         /// <summary>Processes the specified entity.</summary>
         /// <param name="entity">The entity.</param>
-        public override void Process(Entity entity,HealthComponent healthComponent,TransformComponent transformComponent)
+        protected override void Process(Entity entity,HealthComponent healthComponent,TransformComponent transformComponent)
         {
             if (healthComponent != null)
             {

--- a/StarWarrior/StarWarrior/Systems/MovementSystem.cs
+++ b/StarWarrior/StarWarrior/Systems/MovementSystem.cs
@@ -55,7 +55,7 @@ namespace StarWarrior.Systems
     {
         /// <summary>Processes the specified entity.</summary>
         /// <param name="entity">The entity.</param>
-        public override void Process(Entity entity,TransformComponent transformComponent,VelocityComponent velocityComponent)
+        protected override void Process(Entity entity,TransformComponent transformComponent,VelocityComponent velocityComponent)
         {
             if (velocityComponent != null)
             {

--- a/StarWarrior/StarWarrior/Systems/RenderSystem.cs
+++ b/StarWarrior/StarWarrior/Systems/RenderSystem.cs
@@ -76,7 +76,7 @@ namespace StarWarrior.Systems
 
         /// <summary>Processes the specified entity.</summary>
         /// <param name="entity">The entity.</param>
-        public override void Process(Entity entity,SpatialFormComponent spatialFormComponent,TransformComponent transformComponent)
+        protected override void Process(Entity entity,SpatialFormComponent spatialFormComponent,TransformComponent transformComponent)
         {
             if (spatialFormComponent != null)
             {


### PR DESCRIPTION
the version of Artemis bundled with StarWarrior requires that EntityProcessingSystem.Process() is "protected"

I forgot that I had to do this also in order to build.  Sorry for the inconvenience
